### PR TITLE
Retain Windows EOL, explicitly call node in tests

### DIFF
--- a/__tests__/cli.js
+++ b/__tests__/cli.js
@@ -10,27 +10,27 @@ const cliFilePath = path.join(__dirname, '../cli.js');
 const yarnLockFilePath = path.join(__dirname, '../__fixtures__/yarn.lock');
 
 test('prints duplicates', async () => {
-  const { stdout, stderr } = await exec(`${cliFilePath} --list ${yarnLockFilePath}`);
+  const { stdout, stderr } = await exec(`node ${cliFilePath} --list ${yarnLockFilePath}`);
   expect(stdout).toMatch(/^.+\n$/);
   expect(stderr).toBe('');
 });
 
 test('prints fixed yarn.lock', async () => {
-  const { stdout, stderr } = await exec(`${cliFilePath} --print ${yarnLockFilePath}`);
+  const { stdout, stderr } = await exec(`node ${cliFilePath} --print ${yarnLockFilePath}`);
   expect(stdout).not.toContain('lodash@>=1.0.0:');
   expect(stdout).toContain('lodash@>=1.0.0, lodash@>=2.0.0:');
   expect(stderr).toBe('');
 });
 
 test('prints fixed yarn.lock when listing lodash package', async () => {
-  const { stdout, stderr } = await exec(`${cliFilePath} --print --packages lodash ${yarnLockFilePath}`);
+  const { stdout, stderr } = await exec(`node ${cliFilePath} --print --packages lodash ${yarnLockFilePath}`);
   expect(stdout).not.toContain('lodash@>=1.0.0:');
   expect(stdout).toContain('lodash@>=1.0.0, lodash@>=2.0.0:');
   expect(stderr).toBe('');
 });
 
 test('prints same yarn.lock when listing missing package', async () => {
-  const { stdout, stderr } = await exec(`${cliFilePath} --print --packages foo ${yarnLockFilePath}`);
+  const { stdout, stderr } = await exec(`node ${cliFilePath} --print --packages foo ${yarnLockFilePath}`);
   expect(stdout).toContain('lodash@>=1.0.0:');
   expect(stdout).not.toContain('lodash@>=1.0.0, lodash@>=2.0.0:');
   expect(stderr).toBe('');
@@ -39,7 +39,7 @@ test('prints same yarn.lock when listing missing package', async () => {
 test('edits yarn.lock and replaces its content with the fixed version', async () => {
   const oldFileContent = await readFile(yarnLockFilePath, 'utf8');
   try {
-    const { stdout, stderr } = await exec(`${cliFilePath} ${yarnLockFilePath}`);
+    const { stdout, stderr } = await exec(`node ${cliFilePath} ${yarnLockFilePath}`);
     const newFileContent = await readFile(yarnLockFilePath, 'utf8');
     expect(oldFileContent).not.toBe(newFileContent);
     expect(oldFileContent).toContain('lodash@>=1.0.0:');
@@ -48,6 +48,19 @@ test('edits yarn.lock and replaces its content with the fixed version', async ()
     expect(newFileContent).toContain('lodash@>=1.0.0, lodash@>=2.0.0:');
     expect(stdout).toBe('');
     expect(stderr).toBe('');
+  } finally {
+    await writeFile(yarnLockFilePath, oldFileContent, 'utf8');
+  }
+});
+
+test('line endings are retained', async () => {
+  const oldFileContent = await readFile(yarnLockFilePath, 'utf8');
+  try {
+    await exec(`node ${cliFilePath} ${yarnLockFilePath}`);
+    const newFileContent = await readFile(yarnLockFilePath, 'utf8');
+    const oldEol = oldFileContent.match(/(\r?\n)/)[0];
+    const newEol = newFileContent.match(/(\r?\n)/)[0];
+    expect(newEol).toBe(oldEol);
   } finally {
     await writeFile(yarnLockFilePath, oldFileContent, 'utf8');
   }

--- a/__tests__/cli.js
+++ b/__tests__/cli.js
@@ -1,8 +1,9 @@
+const childProcess = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const { promisify } = require('util');
 
-const exec = promisify(require('child_process').exec);
+const execFile = promisify(childProcess.execFile);
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
 
@@ -10,27 +11,47 @@ const cliFilePath = path.join(__dirname, '../cli.js');
 const yarnLockFilePath = path.join(__dirname, '../__fixtures__/yarn.lock');
 
 test('prints duplicates', async () => {
-  const { stdout, stderr } = await exec(`node ${cliFilePath} --list ${yarnLockFilePath}`);
+  const { stdout, stderr } = await execFile(process.execPath, [
+    cliFilePath,
+    '--list',
+    yarnLockFilePath,
+  ]);
   expect(stdout).toMatch(/^.+\n$/);
   expect(stderr).toBe('');
 });
 
 test('prints fixed yarn.lock', async () => {
-  const { stdout, stderr } = await exec(`node ${cliFilePath} --print ${yarnLockFilePath}`);
+  const { stdout, stderr } = await execFile(process.execPath, [
+    cliFilePath,
+    '--print',
+    yarnLockFilePath,
+  ]);
   expect(stdout).not.toContain('lodash@>=1.0.0:');
   expect(stdout).toContain('lodash@>=1.0.0, lodash@>=2.0.0:');
   expect(stderr).toBe('');
 });
 
 test('prints fixed yarn.lock when listing lodash package', async () => {
-  const { stdout, stderr } = await exec(`node ${cliFilePath} --print --packages lodash ${yarnLockFilePath}`);
+  const { stdout, stderr } = await execFile(process.execPath, [
+    cliFilePath,
+    '--print',
+    '--packages',
+    'lodash',
+    yarnLockFilePath,
+  ]);
   expect(stdout).not.toContain('lodash@>=1.0.0:');
   expect(stdout).toContain('lodash@>=1.0.0, lodash@>=2.0.0:');
   expect(stderr).toBe('');
 });
 
 test('prints same yarn.lock when listing missing package', async () => {
-  const { stdout, stderr } = await exec(`node ${cliFilePath} --print --packages foo ${yarnLockFilePath}`);
+  const { stdout, stderr } = await execFile(process.execPath, [
+    cliFilePath,
+    '--print',
+    '--packages',
+    'foo',
+    yarnLockFilePath,
+  ]);
   expect(stdout).toContain('lodash@>=1.0.0:');
   expect(stdout).not.toContain('lodash@>=1.0.0, lodash@>=2.0.0:');
   expect(stderr).toBe('');
@@ -39,7 +60,10 @@ test('prints same yarn.lock when listing missing package', async () => {
 test('edits yarn.lock and replaces its content with the fixed version', async () => {
   const oldFileContent = await readFile(yarnLockFilePath, 'utf8');
   try {
-    const { stdout, stderr } = await exec(`node ${cliFilePath} ${yarnLockFilePath}`);
+    const { stdout, stderr } = await execFile(process.execPath, [
+      cliFilePath,
+      yarnLockFilePath,
+    ]);
     const newFileContent = await readFile(yarnLockFilePath, 'utf8');
     expect(oldFileContent).not.toBe(newFileContent);
     expect(oldFileContent).toContain('lodash@>=1.0.0:');
@@ -56,7 +80,10 @@ test('edits yarn.lock and replaces its content with the fixed version', async ()
 test('line endings are retained', async () => {
   const oldFileContent = await readFile(yarnLockFilePath, 'utf8');
   try {
-    await exec(`node ${cliFilePath} ${yarnLockFilePath}`);
+    const { stdout, stderr } = await execFile(process.execPath, [
+      cliFilePath,
+      yarnLockFilePath,
+    ]);
     const newFileContent = await readFile(yarnLockFilePath, 'utf8');
     const oldEol = oldFileContent.match(/(\r?\n)/)[0];
     const newEol = newFileContent.match(/(\r?\n)/)[0];

--- a/cli.js
+++ b/cli.js
@@ -27,7 +27,7 @@ try {
             includePackages: commander.packages,
         }).forEach(logLine => console.log(logLine))
     }else {
-        const dedupedYarnLock = fixDuplicates(yarnLock,{
+        let dedupedYarnLock = fixDuplicates(yarnLock, {
             useMostCommon: commander.mostCommon,
             includePackages: commander.packages,
         });
@@ -35,6 +35,10 @@ try {
         if (commander.print) {
             console.log(dedupedYarnLock);
         } else {
+            const eolMatch = yarnLock.match(/(\r?\n)/);
+            if (eolMatch && eolMatch[0] === '\r\n') {
+                dedupedYarnLock = dedupedYarnLock.replace(/\n/g, '\r\n');
+            }
             fs.writeFileSync(file, dedupedYarnLock);
         }
     }


### PR DESCRIPTION
This PR is to retain the EOL in the yarn.lock after deduplicating on Windows. I noticed this issue when every line in my yarn.lock file was changed after running yarn-deduplicate.

See this link for how `yarn` achieves this: https://github.com/yarnpkg/yarn/blob/e905f7479ef8ea5ecbc5ca115f0287be709c7d58/src/util/fs.js#L782

I also updated the tests to explicitly call `node` in the `exec` calls, to avoid the assumption that developers have `node` as the default application for js files. For me, each cli test was failing and would open `cli.js` in my editor 😄.