### PR TITLE
Add support for node@6 again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
       - run: node ./cli.js --help
       - run: node ./cli.js --list __fixtures__/yarn.lock
       - run: node ./cli.js --print __fixtures__/yarn.lock
+      - run: node ./cli.js -s fewer __fixtures__/yarn.lock
       - run: node ./cli.js __fixtures__/yarn.lock
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  node8:
     docker:
       - image: circleci/node:8
     working_directory: ~/repo
@@ -10,15 +10,48 @@ jobs:
 
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - {{ CIRCLE_JOB }}-dependencies-{{ checksum "package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - {{ CIRCLE_JOB }}-dependencies-
 
       - run: yarn install
 
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+          key: {{ CIRCLE_JOB }}-dependencies-{{ checksum "package.json" }}
 
       - run: yarn test
+
+  node6:
+    docker:
+      - image: circleci/node:6
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - {{ CIRCLE_JOB }}-dependencies-{{ checksum "package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - {{ CIRCLE_JOB }}-dependencies-
+
+      - run: yarn install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: {{ CIRCLE_JOB }}-dependencies-{{ checksum "package.json" }}
+
+      - run: node ./cli.js --version
+      - run: node ./cli.js --help
+      - run: node ./cli.js --list __fixtures__/yarn.lock
+      - run: node ./cli.js --print __fixtures__/yarn.lock
+      - run: node ./cli.js __fixtures__/yarn.lock
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - node6
+      - node8

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "git@github.com:atlassian/yarn-deduplicate.git"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=6"
   },
   "peerDependencies": {
     "yarn": "^1.0.0"


### PR DESCRIPTION
## Problem

I tried to introduce yarn-deduplicate as a dev dependency to use it in a CI script: https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/21591

We are also checking our asset compilation pipeline to not break on `node@6`, because it is still LTS and supported until March 2019. The `engine >= 8.0` specification in [the package.json](https://github.com/atlassian/yarn-deduplicate/blob/6462b2b/package.json#L28) breaks those tests. For example: https://gitlab.com/gitlab-org/gitlab-ce/-/jobs/132836273

## Solution

After looking at the code base, the only thing which uses features of `node >= 8.0`, are the tests with async/await. The actual CLI works fine for `node@6`, I tested it locally. 

This MR adds E2E to the circle CI config, that run the CLI on a higher level and ensure that there is no funny exit code. It also sets the engine to `>= 6.0`

WDYT, @scinos?