### PR TITLE
Turn cli tests back on

### DIFF
--- a/__tests__/cli.js
+++ b/__tests__/cli.js
@@ -93,7 +93,7 @@ test('line endings are retained', async () => {
     }
 });
 
-test.only('uses fewer strategy', async () => {
+test('uses fewer strategy', async () => {
     const { stdout, stderr } = await execFile(process.execPath, [
         cliFilePath,
         '--print',


### PR DESCRIPTION
I started working on https://github.com/atlassian/yarn-deduplicate/issues/21 -- but I think most of the cli tests have been disabled by this command. 

I don't think this is intentional, so I've tried re-enabling the tests here. 