### PR TITLE
Move ESLint and Prettier to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,16 +34,16 @@
   "dependencies": {
     "@yarnpkg/lockfile": "^1.1.0",
     "commander": "^2.10.0",
+    "semver": "^5.3.0"
+  },
+  "devDependencies": {
     "eslint": "^5.10.0",
     "eslint-config-prettier": "^3.3.0",
     "eslint-plugin-jest": "^22.1.2",
     "eslint-plugin-prettier": "^3.0.0",
-    "prettier": "^1.15.3",
-    "semver": "^5.3.0"
-  },
-  "devDependencies": {
     "jest": "^21.2.1",
-    "outdent": "^0.5.0"
+    "outdent": "^0.5.0",
+    "prettier": "^1.15.3"
   },
   "jest": {
     "testPathIgnorePatterns": [


### PR DESCRIPTION
As far as I can tell, they're not used at runtime, so I think they're intended to be development dependencies only?