### PR TITLE
 feat(CLI): add `yarn.lock` as default value for yarn.lock file path argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 .history
 .vscode
+.idea
 
 # Created by https://www.gitignore.io/api/osx,node,visualstudiocode
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ yarn-deduplicate yarn.lock
 
 This will use the default strategy to remove duplicated packages in `yarn.lock`.
 
+If you do not specify the yarn.lock path, it defaults to `yarn.lock`.
+
 Check all available options with:
 
 ```bash

--- a/cli.js
+++ b/cli.js
@@ -8,7 +8,7 @@ const version = require('./package.json').version;
 
 commander
     .version(version)
-    .usage('[options] <yarn.lock path>')
+    .usage('[options] [yarn.lock path (default: yarn.lock)]')
     .option(
         '-s, --strategy <strategy>',
         'deduplication strategy. Valid values: fewer, highest. Default is "highest"',
@@ -21,14 +21,15 @@ commander
         val => val.split(',').map(v => v.trim())
     )
     .option('--print', 'instead of saving the deduplicated yarn.lock, print the result in stdout');
+
 commander.parse(process.argv);
-if (!commander.args.length) commander.help();
+
 if (commander.strategy !== 'highest' && commander.strategy !== 'fewer') {
     console.error(`Invalid strategy ${commander.strategy}`);
     commander.help();
 }
 
-const file = commander.args[0];
+const file = commander.args.length ? commander.args[0] : 'yarn.lock';
 
 try {
     const yarnLock = fs.readFileSync(file, 'utf8');


### PR DESCRIPTION
Add `yarn.lock` as default value for yarn.lock file path argument to save some time passing the path every time.