### PR TITLE
Allow inclusion of prereleases in deduping behaviour

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,6 +14,7 @@ Joge <joge@application-studios.com>
 Lukas Eipert <git@leipert.io>
 Luke Batchelor <lbatchelor@atlassian.com>
 Maciej Rzymski <mrzymski@atlassian.com>
+Marco De Jongh <mdejongh@atlassian.com>
 Matt Mulder <muldmatt@gmail.com>
 Mike Greiling <mike@pixelcog.com>
 Piotr Łukomiak <cieplak32@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## master
 
+### Chores
+
 - Updated dependency `jest` to 26.6.1
+
+### Added
+
+- Added flag to include pre-release versions in the deduplication process. (thanks to @marcodejongh)
 
 ## [3.0.0] - 2020-10-29
 
 ### Breaking
 
-### Variadic flags
+#### Variadic flags
 
 Flags `--packages`, `--scopes` and `--exclude` don't support comma-separated values anymore (eg:
 `--packages libA,libB`). Instead, you can pass multiple values per flag (eg: `--packages libA libB`)

--- a/__fixtures__/yarn.lock
+++ b/__fixtures__/yarn.lock
@@ -32,3 +32,14 @@ lodash@>=1.0.0:
 lodash@>=2.0.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+
+typescript@^4.1.0-beta:
+  version "4.1.0-beta"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.0-beta.tgz#e4d054035d253b7a37bdc077dd71706508573e69"
+  integrity sha512-b/LAttdVl3G6FEmnMkDsK0xvfvaftXpSKrjXn+OVCRqrwz5WD/6QJOiN+dTorqDY+hkaH+r2gP5wI1jBDmdQ7A==
+
+typescript@^4.0.3:
+  version "4.0.3"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
+  integrity sha1-FTu9Ro7wdyXB35x36LRT+NNqu6U=
+

--- a/__tests__/cli.js
+++ b/__tests__/cli.js
@@ -267,3 +267,18 @@ test('uses fewer strategy', async () => {
     expect(stdout).toContain('resolved "https://example.net/library@^2.1.0"');
     expect(stderr).toBe('');
 });
+
+test('uses includePrerelease option', async () => {
+    const { stdout, stderr } = await execFile(process.execPath, [
+        cliFilePath,
+        '--print',
+        '--includePrerelease',
+        yarnLockFilePath,
+    ]);
+    expect(stdout).not.toContain('typescript@^4.0.3:');
+    expect(stdout).toContain('typescript@^4.0.3, typescript@^4.1.0-beta:');
+    expect(stdout).toContain(
+        'resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.0-beta.tgz#e4d054035d253b7a37bdc077dd71706508573e69"'
+    );
+    expect(stderr).toBe('');
+});

--- a/cli.js
+++ b/cli.js
@@ -26,7 +26,10 @@ commander
     )
     .option('--exclude <exclude...>', 'a list of packages not to deduplicate.')
     .option('--print', 'instead of saving the deduplicated yarn.lock, print the result in stdout')
-    .option('--includePrerelease', 'Include prereleases in version comparisons, e.g. ^1.0.0 will be satisfied by 1.0.0-alpha');
+    .option(
+        '--includePrerelease',
+        'Include prereleases in version comparisons, e.g. ^1.0.0 will be satisfied by 1.0.0-alpha'
+    );
 
 commander.parse(process.argv);
 

--- a/cli.js
+++ b/cli.js
@@ -25,7 +25,8 @@ commander
         'a list of packages to deduplicate. Defaults to all packages.'
     )
     .option('--exclude <exclude...>', 'a list of packages not to deduplicate.')
-    .option('--print', 'instead of saving the deduplicated yarn.lock, print the result in stdout');
+    .option('--print', 'instead of saving the deduplicated yarn.lock, print the result in stdout')
+    .option('--includePrerelease', 'Include prereleases in version comparisons, e.g. ^1.0.0 will be satisfied by 1.0.0-alpha');
 
 commander.parse(process.argv);
 

--- a/cli.js
+++ b/cli.js
@@ -28,7 +28,7 @@ commander
     .option('--print', 'instead of saving the deduplicated yarn.lock, print the result in stdout')
     .option(
         '--includePrerelease',
-        'Include prereleases in version comparisons, e.g. ^1.0.0 will be satisfied by 1.0.0-alpha'
+        'Include prereleases in version comparisons, e.g. ^1.0.0 will be satisfied by 1.0.1-alpha'
     );
 
 commander.parse(process.argv);

--- a/cli.js
+++ b/cli.js
@@ -66,6 +66,7 @@ try {
             includeScopes: commander.scopes,
             includePackages: commander.packages,
             excludePackages: commander.exclude,
+            includePrerelease: commander.includePrerelease,
         });
 
         if (commander.print) {

--- a/index.js
+++ b/index.js
@@ -116,7 +116,10 @@ const getDuplicatedPackages = (
     const packages = extractPackages(json, includeScopes, includePackages, excludePackages);
     return Object.keys(packages)
         .reduce(
-            (acc, name) => acc.concat(computePackageInstances(packages, name, useMostCommon, includePrerelease)),
+            (acc, name) =>
+                acc.concat(
+                    computePackageInstances(packages, name, useMostCommon, includePrerelease)
+                ),
             []
         )
         .filter(({ bestVersion, installedVersion }) => bestVersion !== installedVersion);
@@ -145,7 +148,13 @@ module.exports.listDuplicates = (
 
 module.exports.fixDuplicates = (
     yarnLock,
-    { includeScopes = [], includePackages = [], excludePackages = [], useMostCommon = false, includePrerelease = false } = {}
+    {
+        includeScopes = [],
+        includePackages = [],
+        excludePackages = [],
+        useMostCommon = false,
+        includePrerelease = false,
+    } = {}
 ) => {
     const json = parseYarnLock(yarnLock);
 

--- a/index.js
+++ b/index.js
@@ -127,7 +127,13 @@ const getDuplicatedPackages = (
 
 module.exports.listDuplicates = (
     yarnLock,
-    { includeScopes = [], includePackages = [], excludePackages = [], useMostCommon = false } = {}
+    {
+        includeScopes = [],
+        includePackages = [],
+        excludePackages = [],
+        useMostCommon = false,
+        includePrerelease = false,
+    } = {}
 ) => {
     const json = parseYarnLock(yarnLock);
     const result = [];
@@ -137,6 +143,7 @@ module.exports.listDuplicates = (
         includePackages,
         excludePackages,
         useMostCommon,
+        includePrerelease,
     }).forEach(({ bestVersion, name, installedVersion, requestedVersion }) => {
         result.push(
             `Package "${name}" wants ${requestedVersion} and could get ${bestVersion}, but got ${installedVersion}`

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ const extractPackages = (json, includeScopes = [], includePackages = [], exclude
     return packages;
 };
 
-const computePackageInstances = (packages, name, useMostCommon) => {
+const computePackageInstances = (packages, name, useMostCommon, includePrerelease = false) => {
     // Instances of this package in the tree
     const packageInstances = packages[name];
 
@@ -74,8 +74,8 @@ const computePackageInstances = (packages, name, useMostCommon) => {
             // In some cases the requested version is invalid form a semver point of view (for
             // example `sinon@next`). Just ignore those cases, they won't get deduped.
             if (
-                semver.validRange(packageInstance.requestedVersion) &&
-                semver.satisfies(version, packageInstance.requestedVersion)
+                semver.validRange(packageInstance.requestedVersion, { includePrerelease }) &&
+                semver.satisfies(version, packageInstance.requestedVersion, { includePrerelease })
             ) {
                 satisfies.add(packageInstance);
                 packageInstance.satisfiedBy.add(version);
@@ -98,7 +98,7 @@ const computePackageInstances = (packages, name, useMostCommon) => {
                 if (versions[versionB].satisfies.size < versions[versionA].satisfies.size)
                     return -1;
             }
-            return semver.rcompare(versionA, versionB);
+            return semver.rcompare(versionA, versionB, { includePrerelease });
         });
         packageInstance.satisfiedBy = candidateVersions;
 
@@ -111,12 +111,12 @@ const computePackageInstances = (packages, name, useMostCommon) => {
 
 const getDuplicatedPackages = (
     json,
-    { includeScopes, includePackages, excludePackages, useMostCommon }
+    { includeScopes, includePackages, excludePackages, useMostCommon, includePrerelease = false }
 ) => {
     const packages = extractPackages(json, includeScopes, includePackages, excludePackages);
     return Object.keys(packages)
         .reduce(
-            (acc, name) => acc.concat(computePackageInstances(packages, name, useMostCommon)),
+            (acc, name) => acc.concat(computePackageInstances(packages, name, useMostCommon, includePrerelease)),
             []
         )
         .filter(({ bestVersion, installedVersion }) => bestVersion !== installedVersion);
@@ -145,7 +145,7 @@ module.exports.listDuplicates = (
 
 module.exports.fixDuplicates = (
     yarnLock,
-    { includeScopes = [], includePackages = [], excludePackages = [], useMostCommon = false } = {}
+    { includeScopes = [], includePackages = [], excludePackages = [], useMostCommon = false, includePrerelease = false } = {}
 ) => {
     const json = parseYarnLock(yarnLock);
 
@@ -154,6 +154,7 @@ module.exports.fixDuplicates = (
         includePackages,
         excludePackages,
         useMostCommon,
+        includePrerelease,
     }).forEach(({ bestVersion, name, versions, requestedVersion }) => {
         json[`${name}@${requestedVersion}`] = versions[bestVersion].pkg;
     });


### PR DESCRIPTION
This can be helpful when wanting to dedupe an entire app to use a prerelease
version over a main release version. With this change
`^1.0.0` can be satisfied by `1.0.1-alpha`.

Interestingly `1.0.0-alpha` would not satisify `^1.0.0`, most likely because
it assumes there has already been a non-prerelase at that point